### PR TITLE
Fix ltex default settings, documentation guidelines and typos/capitalization/style fixes via ltex

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -101,7 +101,7 @@ reference page. You can look it up in the following table.
 | [`ltex`](layers/LTEX.md)                 | Grammar checking via LanguageTool                |
 | [`nvimtree`](layers/NVIMTREE.md)         | File explorer tree                               |
 | [`outline`](layers/OUTLINE.md)           | Buffer outline as a tree-like view of symbols    |
-| [`rainbow`](layers/RAINBOW.md)           | Rainbow parenthesis via Treesitter               |
+| [`rainbow`](layers/RAINBOW.md)           | Rainbow parenthesis via Tree-sitter               |
 | [`snippet`](layers/SNIPPET.md)           | Code snippets engine                             |
 | [`statusline`](layers/STATUSLINE.md)     | Customizable status line                         |
 | [`telescope`](layers/TELESCOPE.md)       | Fuzzy finder and related features                |

--- a/docs/contributing/GUIDELINES.md
+++ b/docs/contributing/GUIDELINES.md
@@ -7,7 +7,7 @@ weight: 10
 Thanks for considering helping us out! This page lists the steps required to
 contribute to the `visimp` project.
 
-## Working on a feature/fixing a bug
+## Discussing your contribution
 
 Whether you are working on a new feature or fixing a bug, get in touch with the
 project maintainers via the issue tracker. Please discuss the details of your
@@ -19,11 +19,10 @@ not waste time on contributions that will be rejected.
 Before starting to work on your contribution, make sure you have read the
 [Introduction](INTRO.md), [Config](CONFIG.md), and [Layer](LAYER.md) sections.
 
-## Documenting
+## Writing code
 
-All tables and list in the documentation and in the sample configuration at
-`_init.lua` should be presented in alphabetical order. Capitals letters should
-be used uniformly.
+Depending on which part of the codebase you are working on, you might need to
+take different extra steps.
 
 ### Working on internals
 
@@ -58,6 +57,24 @@ document so in [LANGUAGES](layers/LANGUAGES.md#configuration).
 
 Make sure your language is listed in the sample configuration found in
 `_init.lua`.
+
+## Documenting your contribution
+
+Two types of documentation must be provided:
+
+- every Lua function or field must be annotated through
+  [LuaCATS](https://luals.github.io/wiki/annotations/). The Lua Language Server
+  supports this already;
+- the `docs/` folder contains a user manual written in Markdown. Files therein
+  are decorated with headers compatible with the [Hugo
+  Book](https://github.com/alex-shpak/hugo-book) Hugo theme. This way,
+  [`visimp/pages`](https://github.com/visimp/pages) can reuse the `docs/`
+  folder, too.
+
+All tables and list in the documentation and in the sample configuration at
+`_init.lua` should be presented in alphabetical order. Capitals letters should
+be used uniformly. Please especially mind the capitalizations of "visimp" (which
+can also be monospaced as `visimp`) and "Treee-sitter".
 
 ## Final checks
 

--- a/docs/contributing/LAYER.md
+++ b/docs/contributing/LAYER.md
@@ -9,7 +9,7 @@ piece of your `visimp` configuration in the [introduction](INTRO.md). More
 concretely, a layer `L` is a structure with the following fields:
 
 - `L.identifier` is a unique string that identifies the layer. This identifier
-  is usually a meaningful name, often matching with the lua filename;
+  is usually a meaningful name, often matching with the Lua filename;
 - `L.default_config` is the layer's default configuration to be extended via a
   merge with the configuration given to `L.configure(...)`. Please see the next
   bullet point for further reference;
@@ -40,5 +40,5 @@ appropriate field of the layer Below is a list of available methods.
   methods. An example is the interaction with the `lsp` layer: in order to
   enable a desired LSP, other layers need to specify it in their `preload`
   section before the `lsp` layer `load` method gets called.
-- `L.load()` is designed to let layers apply side-effects on the Neovim client.
+- `L.load()` is designed to let layers apply side effects on the Neovim client.
   This is where plugins are enabled, the Neovim configuration is set, etcetera.

--- a/docs/languages/GLEAM.md
+++ b/docs/languages/GLEAM.md
@@ -1,6 +1,6 @@
 # `gleam` layer
 
-The `gleam` layer enables support for the Gleam pogramming language.
+The `gleam` layer enables support for the Gleam programming language.
 
 ## LSP
 As of this writing, the Gleam LSP is not available in the Mason registry (see

--- a/docs/layers/BLANKLINE.md
+++ b/docs/layers/BLANKLINE.md
@@ -6,7 +6,7 @@ The `blankline` layer adds indentation vertical guides using
 ## Configuration
 
 - `indent_blankline` (`table`): a valid configuration for the
-  `indent-blankline.nvim` plugin, as described in the relevant docs's [`config`
+  `indent-blankline.nvim` plugin, as described in the relevant docs' [`config`
   type](https://github.com/lukas-reineke/indent-blankline.nvim/blob/12e92044d313c54c438bd786d11684c88f6f78cd/doc/indent_blankline.txt);
 - `rainbow_integration` (`table`): if set to a false-ish value, it disables
   integration with the [`rainbow` layer](./RAINBOW.md) even when the latter is

--- a/docs/layers/CMP.md
+++ b/docs/layers/CMP.md
@@ -7,8 +7,8 @@ The `cmp` layer is a dependency for other layers providing a completion engine
 
 In insert mode, with the suggestions list open:
 
-- `<C-d>`: when selecting a suggestions, scrolls the documentation up;
-- `<C-f>`: when selecting a suggestions, scrolls the documentation down;
+- `<C-d>`: when selecting a suggestion, scrolls the documentation up;
+- `<C-f>`: when selecting a suggestion, scrolls the documentation down;
 - `<C-space>`: accepts suggestions;
 - `<C-e>`: closes suggestions list;
 - `<CR>`: accepts the selected suggestion;

--- a/docs/layers/DIAGNOSTICS.md
+++ b/docs/layers/DIAGNOSTICS.md
@@ -18,9 +18,9 @@ In normal mode:
 ## Configuration
 
 - `trouble` (defaults to `{}`) can be any valid configuration for Trouble (whose
-  settings and defaults are documented [here](https://github.com/folke/trouble.nvim#%EF%B8%8F-configuration);
+  settings and defaults are documented [here](https://github.com/folke/trouble.nvim#%EF%B8%8F-configuration));
 - `binds` (default bindings are documented above) as would be passed to the
-  [`binds` layer](BINDS.md) layer.
+  [`binds` layer](BINDS.md).
 
 ## Examples
 

--- a/docs/layers/FUGITIVE.md
+++ b/docs/layers/FUGITIVE.md
@@ -5,7 +5,7 @@ The `fugitive` layer allows you to use git from within vim via the
 
 ## Bindings
 
-When in Fugitive-specific buffers,several bindings can be used as documented
+When in Fugitive-specific buffers, several bindings can be used as documented
 [here](https://github.com/tpope/vim-fugitive/blob/master/doc/fugitive.txt).
 
 

--- a/docs/layers/GREETER.md
+++ b/docs/layers/GREETER.md
@@ -19,7 +19,7 @@ require("visimp")({
 })
 ```
 
-For further explaination on the layout object itself, refer to the following 
+For further explanation on the layout object itself, refer to the following 
 examples and the official `alpha-nvim` repository. In particular, be sure to
 read the FAQs to prevent unwanted interactions with other features.
 

--- a/docs/layers/LANGUAGES.md
+++ b/docs/layers/LANGUAGES.md
@@ -8,7 +8,7 @@ The `languages` layer is in charge of loading languages layers. These usually
 provide language-specific features such as:
 
 - a language server;
-- Treesitter parsers-based functionalities;
+- Tree-sitter parsers-based functionalities;
 - language-specific additional plugins.
 
 ## Configuration
@@ -21,7 +21,7 @@ supported as standard layers rather than language layers, and are documented as
 such.
 
 Individual language layers need to be listed among the standard ones only when
-you want to pass an explicit configuration. Language layers have two commoon
+you want to pass an explicit configuration. Language layers have two common
 settings:
 
 - `lsp`: the LS to use. Defaults to `nil`, meaning visimp will install one from
@@ -40,14 +40,14 @@ Several language layers diverge from this basic configuration:
   support for both languages;
 - `coq` has [its own doc page](../languages/COQ.md);
 - `css` adds the `scss` option (defaults to `false`) which, if set to true,
-  adds Treesitter support for SCSS;
+  adds Tree-sitter support for SCSS;
 - `dart` adds the `flutter` boolean option (defaults to `false`) and the
   `flutterconfig` table option for integration with the Flutter framework;
 - `hcl` adds the `terraform` boolean option (defaults to `true`) to indicate
   whether to use or disable the Terraform LS;
 - `idris` has [its own doc page](../languages/IDRIS.md);
 - `javascript` adds the `typescript` boolean option (defaults to `true`) to
-  add Treesitter support for Typescript;
+  add Tree-sitter support for Typescript;
 - `latex` add the `autocompile` (defaults to `true`) option for automatic
   compilation via LS and the `tectonic` (defaults to `false`) option to ask
   default LS Texlab to compile via Tectonic;

--- a/docs/layers/LSP.md
+++ b/docs/layers/LSP.md
@@ -7,7 +7,7 @@ for layers requiring LSPs, such as most language layers.
 LSs are installed by [mason.nvim](https://github.com/williamboman/mason.nvim)
 by default.
 
-Neovim itself can also act as a LS to inject new LSP-like features via
+Neovim itself can also act as an LS to inject new LSP-like features via
 [none-ls.nvim](https://github.com/nvimtools/none-ls.nvim), a community fork of
 the discontinued "null-ls.nvim". All documentation and code still refer to
 null-ls, as none-ls does not rename its API for compatibility concerns.
@@ -96,7 +96,7 @@ Returns the list of "on-attach-one-time"-like handlers.
 
 ### `get_capabilities()`
 
-Returns the capabilities handler.
+Returns the capabilities' handler.
 
 ## Documentation
 

--- a/docs/layers/LTEX.md
+++ b/docs/layers/LTEX.md
@@ -1,8 +1,8 @@
 # `ltex` layer
 
 The `ltex` layer provides grammar checking by
-[LanguageTool](https://languagetool.org) as a LS for markup documents ($\LaTeX$,
-Markdown, ...).
+[LanguageTool](https://languagetool.org) as an LS for markup documents
+($\LaTeX$, Markdown, ...).
 
 ## Configuration
 

--- a/docs/layers/RAINBOW.md
+++ b/docs/layers/RAINBOW.md
@@ -1,9 +1,9 @@
 # `rainbow` layer
 
 The `rainbow` layer provides alternating syntax highlighting ("rainbow
-parenthesis") for languages with a Treesitter parser installed. To do so, it
+parenthesis") for languages with a Tree-sitter parser installed. To do so, it
 uses the [rainbow-delimiters.nvim
-plugin](https://lab.vern.cc/gitlab.com/HiPhish/rainbow-delimiters.nvim/)
+plugin](https://lab.vern.cc/gitlab.com/HiPhish/rainbow-delimiters.nvim/).
 
 ## Configuration
 

--- a/docs/layers/STATUSLINE.md
+++ b/docs/layers/STATUSLINE.md
@@ -8,7 +8,7 @@ The `statusline` layer offers a new statusline, namely
 A lualine.nvim configuration as described
 [here](https://github.com/nvim-lualine/lualine.nvim#usage-and-customization).
 
-Visimp sets a handful of resonable defaults for you from `options`, `sections`,
+Visimp sets a handful of reasonable defaults for you from `options`, `sections`,
 and `inactive_sections`.
 
 If no `theme` option is explicitly passed, visimp will fetch the theme from the

--- a/docs/layers/THEME.md
+++ b/docs/layers/THEME.md
@@ -5,7 +5,7 @@ The `theme` layer is tasked with setting a theme.
 ## Configuration
 
 - `package` (default `'gruvbox-community/gruvbox'`) is the theme repository.
-  Could be either be a table with an `url` string field or a string to be
+  Could be either be a table with a `url` string field or a string to be
   appended to `'https://github.com/'`;
 - `colorscheme` (default `'gruvbox'`) is the colorscheme name;
 - `background` (default `dark`) is equivalent to Neovim's `background` option;

--- a/docs/layers/TREESITTER.md
+++ b/docs/layers/TREESITTER.md
@@ -1,7 +1,7 @@
 # `treesitter` layer
 
 The `treesitter` layer is a dependency layer providing languages layers with
-Treesitter support.
+Tree-sitter support.
 
 ## Configuration
 
@@ -25,5 +25,5 @@ require("visimp")({
 
 ### `langs(languages)`
 
-This method ensures the treesitter parsers passed as a list of strings
+This method ensures the Tree-sitter parsers passed as a list of strings
 (`languages`) are installed.

--- a/docs/layers/WHICHKEY.md
+++ b/docs/layers/WHICHKEY.md
@@ -1,6 +1,6 @@
 # `whichkey` layer
 
-The `whichkey` layer provides a popup for possible key bindings for the command
+The `whichkey` layer provides a pop-up for possible key bindings for the command
 you started typing via the [WhichKey plugin](https://github.com/folke/which-key.nvim).
 
 ## Configuration

--- a/docs/layers/ZEN.md
+++ b/docs/layers/ZEN.md
@@ -1,7 +1,8 @@
 # `zen` layer
 
 The `zen` layer offers a Zen mode in which most UI elements are hidden to
-prevent distraction. To do so, it uses the [Zen Mode plugin](https://github.com/folke/zen-mode.nvim)
+prevent distraction. To do so, it uses the [Zen Mode
+plugin](https://github.com/folke/zen-mode.nvim).
 
 ## Configuration
 

--- a/lua/visimp/language.lua
+++ b/lua/visimp/language.lua
@@ -16,14 +16,14 @@ end
 ---@return table dependencies List of dependencies
 local function language_layer_dependencies(l)
   local deps
-  -- treesitter
+  -- Tree-sitter
   local grammars = l.grammars()
   if type(grammars) ~= 'table' or is_empty(grammars) then
     deps = {}
   else
     deps = { 'treesitter' }
   end
-  -- lsp
+  -- LSP
   if l.config.lsp ~= false then
     table.insert(deps, 'lsp')
   end
@@ -39,8 +39,8 @@ local function add_filetypes(filetypes)
   end
 end
 
----Adds the specified languages to Treesitter
----@param grammars table Array of Treesitter grammar names
+---Adds the specified languages to Tree-sitter
+---@param grammars table Array of Tree-sitter grammar names
 local function add_grammars(grammars)
   if not grammars then
     return

--- a/lua/visimp/languages/c.lua
+++ b/lua/visimp/languages/c.lua
@@ -17,7 +17,7 @@ local function use_server(language)
 end
 
 function L.preload()
-  -- Configure treesitter
+  -- Configure Tree-sitter
   local langs = {}
   if L.config.c then
     table.insert(langs, 'c')

--- a/lua/visimp/languages/dart.lua
+++ b/lua/visimp/languages/dart.lua
@@ -29,7 +29,7 @@ function L.packages()
 end
 
 function L.preload()
-  -- Configure treesitter
+  -- Configure Tree-sitter
   layers.get('treesitter').langs { 'dart' }
 
   if L.config.flutter then

--- a/lua/visimp/layers/ltex.lua
+++ b/lua/visimp/layers/ltex.lua
@@ -6,7 +6,9 @@ local layers = require 'visimp.loader'
 ---https://github.com/neovim/nvim-lspconfig/blob/master/doc/
 ---server_configurations.md#ltex are accepted here.
 L.default_config = {
-  language = 'en-US',
+  ltex = {
+    language = 'en-US',
+  },
 }
 
 function L.dependencies()


### PR DESCRIPTION
Fix: ltex default config (commit message says latex, whoopsie!). All ltex settings are under the "ltex" namespace.

Guidelines on how to document code are now more complete.

Fixed a bunch of typos, capitalization, punctuation, and style problems via ltex.