### PR TITLE
feat: deprecate impatient in favor of vim.loader

### DIFF
--- a/lua/visimp/layers/defaults.lua
+++ b/lua/visimp/layers/defaults.lua
@@ -16,13 +16,7 @@ L.default_config = {
   completeopt = 'menuone,noinsert,noselect',
 }
 
-function L.packages()
-  return { 'lewis6991/impatient.nvim' }
-end
-
 function L.load()
-  get_module 'impatient'
-
   opt('o', 'swapfile', false) -- Do not use swap files
   opt('o', 'backup', false) -- Do not use backups
   opt('o', 'writebackup', false) -- Do not write backups

--- a/lua/visimp/layers/defaults.lua
+++ b/lua/visimp/layers/defaults.lua
@@ -2,7 +2,6 @@ local L = require('visimp.layer').new_layer 'defaults'
 local bridge = require 'visimp.bridge'
 local opt = bridge.opt
 local vfn = bridge.vfn
-local get_module = bridge.get_module
 
 L.default_config = {
   mapleader = ' ',

--- a/lua/visimp/setup.lua
+++ b/lua/visimp/setup.lua
@@ -41,6 +41,7 @@ end
 ---Configures the visimp distributions and its layers
 ---@param visimp_cfg table The configuration table
 function M.setup(visimp_cfg)
+  vim.loader.enable()
   M.configs = visimp_cfg or {}
   pak.register 'visimp/visimp' -- Let visimp be updated by the package manager
 


### PR DESCRIPTION
Closes #118. The [`vim.loader` table](https://github.com/visimp/visimp/pull/new/feat/vim-loader) appears to be experimental, so I am not sure we should merge this immediately.