### PR TITLE
feat!: replace typst-lsp with tinymist

### DIFF
--- a/lua/visimp/languages/typst.lua
+++ b/lua/visimp/languages/typst.lua
@@ -1,19 +1,11 @@
 local L = require('visimp.language').new_language 'typst'
 
-function L.filetypes()
-  return {
-    extension = {
-      typ = 'typst',
-    },
-  }
-end
-
 function L.grammars()
   return { 'typst' }
 end
 
 function L.server()
-  return 'typst_lsp'
+  return 'tinymist'
 end
 
 return L


### PR DESCRIPTION
Closes #134. As of neovim 0.10, there is no more need for declaring Typst's filetype explicitly.