### PR TITLE
feat: visimp mason registry

### DIFF
--- a/lua/visimp/layers/lsp.lua
+++ b/lua/visimp/layers/lsp.lua
@@ -15,12 +15,15 @@ L.default_config = {
   install = true,
   ---Can be set to nil to disable LSP progress reports
   progress = {},
+  ---A valid mason.nvim configuration
   mason = {
     registries = {
       'github:mason-org/mason-registry',
       'github:visimp/mason-registry',
     },
   },
+  ---A valid mason-tool-installer.nvim configuration
+  mason_tool_installer = {},
   ---Strings used as keys are considered null-ls source names, and their values
   ---the respective configs. When non-strings are used as keys (e.g. implicit
   ---number indices in arrays), their values are assumed to be null-ls source
@@ -132,6 +135,7 @@ function L.packages()
     'neovim/nvim-lspconfig',
     { 'williamboman/mason.nvim', opt = true },
     { 'williamboman/mason-lspconfig.nvim', opt = true },
+    { 'WhoIsSethDaniel/mason-tool-installer.nvim', opt = true },
     -- TODO: should be optional as its required by null-ls, itself being an
     -- optional dependency. This currently cannot be achieved as it'll break
     -- other packages which have a hard dependency on plenary. This fix belongs
@@ -166,6 +170,7 @@ function L.load()
   if L.config.install then
     vim.cmd 'packadd mason.nvim'
     vim.cmd 'packadd mason-lspconfig.nvim'
+    vim.cmd 'packadd mason-tool-installer.nvim'
     get_module('mason').setup(L.config.mason or {})
 
     local required = {}
@@ -174,9 +179,13 @@ function L.load()
         table.insert(required, srv.server)
       end
     end
-    get_module('mason-lspconfig').setup {
-      ensure_installed = required,
-    }
+    get_module('mason-tool-installer').setup(
+      vim.tbl_deep_extend(
+        'force',
+        { ensure_installed = required },
+        L.config.mason_tool_installer
+      )
+    )
   end
 
   if L.config.progress ~= nil then

--- a/lua/visimp/layers/lsp.lua
+++ b/lua/visimp/layers/lsp.lua
@@ -15,7 +15,12 @@ L.default_config = {
   install = true,
   ---Can be set to nil to disable LSP progress reports
   progress = {},
-  mason = {},
+  mason = {
+    registries = {
+      'github:mason-org/mason-registry',
+      'github:visimp/mason-registry',
+    },
+  },
   ---Strings used as keys are considered null-ls source names, and their values
   ---the respective configs. When non-strings are used as keys (e.g. implicit
   ---number indices in arrays), their values are assumed to be null-ls source


### PR DESCRIPTION
Closes #124.

This PR enables [visimp's mason package registry](https://github.com/visimp/mason-registry) as a default **fallback** registry when a package is not available on the core package registry. No action on the user's side is required, as mason.nvim [automatically updates the registries](https://github.com/williamboman/mason.nvim#registries) when the relevant mason commands are invoked.

Adding the registry is just groundwork. We also need to specify the relevant LSs in our language layers (as we add them). We can recycle the nvim-lspconfig LS names as our package names, so that `mason-tool-installer.nvim` automatically installs them.