### PR TITLE
feat: rename coq to rocq

### DIFF
--- a/lua/visimp/languages/coq.lua
+++ b/lua/visimp/languages/coq.lua
@@ -1,13 +1,3 @@
-local layer = require 'visimp.layer'
-local L = layer.new_layer 'coq'
-
-function L.packages()
-  return { 'whonore/Coqtail' }
-end
-
-function L.load()
-  vim.cmd 'packadd Coqtail'
-  layer.to_vimscript_config(L, 'coqtail_', true)
-end
-
-return L
+local coqLayer = vim.deepcopy(require 'visimp.languages.rocq')
+coqLayer.identifier = 'coq'
+return coqLayer

--- a/lua/visimp/languages/coq.lua
+++ b/lua/visimp/languages/coq.lua
@@ -1,3 +1,4 @@
 local coqLayer = vim.deepcopy(require 'visimp.languages.rocq')
 coqLayer.identifier = 'coq'
+coqLayer.deprecated = true
 return coqLayer

--- a/lua/visimp/languages/rocq.lua
+++ b/lua/visimp/languages/rocq.lua
@@ -1,0 +1,13 @@
+local layer = require 'visimp.layer'
+local L = layer.new_layer 'rocq'
+
+function L.packages()
+  return { 'whonore/Coqtail' }
+end
+
+function L.load()
+  vim.cmd 'packadd Coqtail'
+  layer.to_vimscript_config(L, 'coqtail_', true)
+end
+
+return L


### PR DESCRIPTION
Rename the `coq` language layer to `rocq` according to the [recent renaming](https://github.com/coq/rfcs/blob/coq-roadmap/text/069-coq-roadmap.md#change-of-name-coq---the-rocq-prover.) of such programming language/theorem prover.

This is no breaking change, as the old layer is actually still available. It is generated as a deep copy of the new `rocq` layer to prevent code duplication.

Should I add a deprecation warning on load?