### PR TITLE
feat: Prolog LS + tree-sitter grammar

### DIFF
--- a/lua/visimp/languages/prolog.lua
+++ b/lua/visimp/languages/prolog.lua
@@ -1,9 +1,5 @@
 local L = require('visimp.language').new_language 'prolog'
 
-function L.packages()
-  return { 'XVilka/prolog-vim' }
-end
-
 function L.filetypes()
   return {
     extension = {
@@ -14,14 +10,8 @@ function L.filetypes()
   }
 end
 
---[[ TODO: https://github.com/mason-org/mason-registry/pull/4011 10-04-24,
--- Stefano Volpe foxy@teapot.ovh ]]
--- function L.server()
---   return 'prolog-language-server'
--- end
-
-function L.load()
-  vim.cmd 'packadd prolog-vim'
+function L.server()
+  return 'prolog_ls'
 end
 
 return L

--- a/lua/visimp/languages/prolog.lua
+++ b/lua/visimp/languages/prolog.lua
@@ -10,6 +10,10 @@ function L.filetypes()
   }
 end
 
+function L.grammars()
+  return { 'prolog' }
+end
+
 function L.server()
   return 'prolog_ls'
 end


### PR DESCRIPTION
Closes #85. The original vimscript plugin (which has been archived in the meantime) is not needed anymore.