### PR TITLE
feat: a/e/i/<CR> now exit greeter

### DIFF
--- a/lua/visimp/layers/greeter.lua
+++ b/lua/visimp/layers/greeter.lua
@@ -11,53 +11,6 @@ local function vim_version()
   return 'running on NVIM v' .. tostring(vim.version())
 end
 
----A substring to be used to represent the leader button (space) on screen.
-local leader = 'SPC'
-
----From
----https://github.com/goolord/alpha-nvim/blob/main/lua/alpha/themes/startify.lua
----@param sc string
----@param txt string
----@param keybind string? optional
----@param keybind_opts table? optional
-local function button(sc, txt, keybind, keybind_opts)
-  local sc_ = sc:gsub('%s', ''):gsub(leader, '<leader>')
-
-  local opts = {
-    position = 'center',
-    shortcut = '[' .. sc .. '] ',
-    cursor = 1,
-    -- width = 50,
-    align_shortcut = 'left',
-    hl_shortcut = {
-      { 'Operator', 0, 1 },
-      { 'Number', 1, #sc + 1 },
-      { 'Operator', #sc + 1, #sc + 2 },
-    },
-    shrink_margin = false,
-  }
-  if keybind then
-    keybind_opts = vim.F.if_nil(
-      keybind_opts,
-      { noremap = true, silent = true, nowait = true }
-    )
-    opts.keymap = { 'n', sc_, keybind, keybind_opts }
-  end
-
-  local function on_press()
-    local key =
-      vim.api.nvim_replace_termcodes(keybind .. '<Ignore>', true, false, true)
-    vim.api.nvim_feedkeys(key, 't', false)
-  end
-
-  return {
-    type = 'button',
-    val = txt,
-    on_press = on_press,
-    opts = opts,
-  }
-end
-
 ---Default greeter
 ---@return table layout alpha-nvim layout describing visimp's default greeter
 local function default_layout()
@@ -88,6 +41,16 @@ local function default_layout()
     },
   }
 
+  local continue = {
+    type = 'button',
+    val = '',
+    opts = { position = 'center' },
+    on_press = function()
+      vim.cmd 'ene'
+      vim.cmd 'startinsert'
+    end,
+  }
+
   local footer = {
     type = 'text',
     val = fortune(),
@@ -101,15 +64,17 @@ local function default_layout()
     layout = {
       { type = 'padding', val = 12 },
       header,
-      { type = 'padding', val = 2 },
+      { type = 'padding', val = 1 },
       version,
-      { type = 'padding', val = 2 },
+      { type = 'padding', val = 1 },
+      continue,
       footer,
-      { type = 'padding', val = 2 },
-      button('e', 'New file', '<cmd>ene | startinsert <CR>'),
     },
     opts = {
       margin = 5,
+      keymap = {
+        press = { 'a', 'i', 'o', '<CR>' },
+      },
     },
   }
 end


### PR DESCRIPTION
Pressing a, e, i, or <CR> not exits the greeter. There is no visible button (the cursor cannot be made invisible though).

![24-02-2025-03-13-56](https://github.com/user-attachments/assets/4002758b-dc9e-4154-9f44-4696d3e95470)
