### PR TITLE
fix: .luarc.json for neovim plugin

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
-  "Lua.diagnostics.globals": [
-    "vim"
-  ],
   "runtime.version": "LuaJIT",
   "workspace": {
     "checkThirdParty": false,

--- a/.luarc.json
+++ b/.luarc.json
@@ -3,5 +3,10 @@
   "Lua.diagnostics.globals": [
     "vim"
   ],
-  "runtime.version": "Lua 5.1"
+  "runtime.version": "LuaJIT",
+  "workspace": {
+    "checkThirdParty": false,
+    "library": ["/usr/share/nvim/runtime"]
+  },
+  "diagnostics.libraryFiles": "Disable"
 }


### PR DESCRIPTION
See https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#lua_ls

Now our "requires" actually fetch the type of the imported module.