### PR TITLE
migration to new nvim-treesitter apis

### DIFF
--- a/lua/visimp/layers/treesitter.lua
+++ b/lua/visimp/layers/treesitter.lua
@@ -20,10 +20,8 @@ function L.load()
       additional_vim_regex_highlighting = false,
     },
     indent = { enable = L.config.indent },
+    ensure_installed = L.languages,
   }
-
-  local ts = get_module 'nvim-treesitter.install'
-  ts.ensure_installed(L.languages)
 end
 
 ---Ensures the given tree sitter parsers are installed

--- a/lua/visimp/layers/treesitter.lua
+++ b/lua/visimp/layers/treesitter.lua
@@ -13,7 +13,7 @@ function L.packages()
 end
 
 function L.load()
-  local config = get_module 'nvim-treesitter.configs'
+  local config = get_module 'nvim-treesitter.config'
   config.setup {
     highlight = {
       enable = L.config.highlight,


### PR DESCRIPTION
Hey! I fixed a small issue with `nvim-treesitter`.

The plugin's default branch was switched from `master` to `main` a few months ago. `master` won't be maintained anymore. Some breaking changes in the APIs have been introduced in `main`. You can read a bit about it in this [discussion thread](https://github.com/nvim-treesitter/nvim-treesitter/discussions/7927). Unfortunately, there's neither a migration guide nor much documentation about it - or at least I wasn't able to find it.

Anyhow, I was getting this error:
```
Error detected while processing /home/elena/.config/nvim/init.lua:
E5113: Error while calling lua chunk: ...nvim/site/pack/packer/start/visimp/lua/visimp/bridge.lua:21: Plugin 'nvim-treesitter.configs'not installed:
module 'nvim-treesitter.configs' not found:
        no field package.preload['nvim-treesitter.configs']
        cache_loader: module 'nvim-treesitter.configs' not found
        cache_loader_lib: module 'nvim-treesitter.configs' not found
```
In my understanding, two of the changes they introduced are renaming `nvim-treesitter.configs` to `nvim-treesitter.config` and moving `ensure_installed` from the `install` module to the `config` module.

With these fixes I was able to get it working again. Let me know if this is fine :)