### PR TITLE
fix: Ltex_plux configuration

### DIFF
--- a/lua/visimp/layers/copilot.lua
+++ b/lua/visimp/layers/copilot.lua
@@ -1,0 +1,9 @@
+local L = require('visimp.layer'):new_layer 'copilot'
+
+function L.packages()
+  return {
+    'github/copilot.vim',
+  }
+end
+
+return L

--- a/lua/visimp/layers/copilot.lua
+++ b/lua/visimp/layers/copilot.lua
@@ -1,9 +1,14 @@
 local L = require('visimp.layer'):new_layer 'copilot'
+local layer = require 'visimp.layer'
 
 function L.packages()
   return {
     'github/copilot.vim',
   }
+end
+
+function L.load()
+  layer.to_vimscript_config(L, 'copilot_', true)
 end
 
 return L

--- a/lua/visimp/layers/ltex.lua
+++ b/lua/visimp/layers/ltex.lua
@@ -14,7 +14,7 @@ function L.dependencies()
 end
 
 function L.preload()
-  -- If the user has provided a config, we wrap it 
+  -- If the user has provided a config, we wrap it
   -- into the ltex config
   local cfg = L.config and { ltex = L.config } or {}
   layers

--- a/lua/visimp/layers/ltex.lua
+++ b/lua/visimp/layers/ltex.lua
@@ -6,9 +6,7 @@ local layers = require 'visimp.loader'
 ---https://github.com/neovim/nvim-lspconfig/blob/master/doc/
 ---server_configurations.md#ltex are accepted here.
 L.default_config = {
-  ltex = {
-    language = 'en-US',
-  },
+  language = 'en-US',
 }
 
 function L.dependencies()
@@ -16,9 +14,12 @@ function L.dependencies()
 end
 
 function L.preload()
+  -- If the user has provided a config, we wrap it 
+  -- into the ltex config
+  local cfg = L.config and { ltex = L.config } or {}
   layers
     .get('lsp') --[[@as LspLayer]]
-    :use_server('ltex', true, 'ltex_plus', L.config or {})
+    :use_server('ltex', true, 'ltex_plus', cfg)
 end
 
 return L

--- a/lua/visimp/layers/ltex.lua
+++ b/lua/visimp/layers/ltex.lua
@@ -14,12 +14,9 @@ function L.dependencies()
 end
 
 function L.preload()
-  -- If the user has provided a config, we wrap it
-  -- into the ltex config
-  local cfg = L.config and { ltex = L.config } or {}
   layers
     .get('lsp') --[[@as LspLayer]]
-    :use_server('ltex', true, 'ltex_plus', cfg)
+    :use_server('ltex', true, 'ltex_plus', { ltex = L.config })
 end
 
 return L


### PR DESCRIPTION
Hello there, 

I recently discovered that the example provided in Visimp's documentation [here](https://visimp.teapot.ovh/docs/layers/ltex/) is incorrect. ltex_plus wraps its configuration in an additional object, so with the current version of Visimp the correct configuration should be:
```lua
-- path/of/your/vim/config/init.lua

require("visimp")({
  ltex = {
    ltex = {
      language = "de-DE",
      dictionary = {
        ["en-US"] = {
          "adaptivity",
          "precomputed",
          "subproblem"
        },
        ["de-DE"] = {
          "B-Splines",
          ":/path/to/externalFile.txt"
        },
      },
    }
  },
})
```

Which is arguably not ideal to write. ^_^

We can either keep the current behavior and update the documentation, or modify the layer so that it automatically wraps the user configuration. I believe the latter approach provides a better user experience, which is why I opened this PR.

PS:
I may have fucked up with the curly braces in the example, but you get the idea.
Also, not sure why the git history is showing old commits